### PR TITLE
output empty label in chart hover

### DIFF
--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -61,7 +61,7 @@ export class BarChart extends React.Component {
       },
 
       data: {
-        labels: ["Record Meter"],
+        labels: [""], // this empty label must remain, if removed the entire chart breaks
         datasets: this.props.data.map((d) => d.data),
       },
     });

--- a/src/lib/getFeeds.js
+++ b/src/lib/getFeeds.js
@@ -8,9 +8,9 @@ export default function getFeeds() {
     post_type_breakdown: {
       post: 104,
       page: 17,
-      attachment: 38,
+      attachment: 15,
       anotherone: 21,
-      averyveryextrasuperlongernamesposttypethatgoesonandonandone: 15,
+      averyveryextrasuperlongernamesposttypethatgoesonandonandone: 38,
       more: 22,
       andmore: 4,
       moremoremore: 2,


### PR DESCRIPTION
Outputs and empty label on the chart hover, omitting it from the display so things fit better. 

fixes #15 