### PR TITLE
Fix overlapping legend and notice

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,7 +44,7 @@ ul.chartLegend {
 .noticeBox {
   border: solid .5px lightgrey;
   margin-left: 5px;
-  padding: 0px 5px;
+  padding: 0 5px;
 
 }
 

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -71,57 +71,60 @@ export class BarChart extends React.Component {
 
   render() {
     return (
-      <div className="chartContainer">
-        <canvas ref={this.canvasRef}>
-          <p>
-            Text alternative for this canvas graphic is in the data table below.
-          </p>
-        <table
-          border="0"
-          cellPadding="5"
-          summary="This is the text alternative for the canvas graphic."
-        >
-          <caption>Records Indexed for Jetpack Search</caption>
-          <tbody>
-            <tr>
-              <th scope="col">Post Type</th>
-              {this.state?.legendItems.length &&
-                this.state.legendItems.map((item) => {
-                  return <th scope="col">{item.text}</th>;
-                })}
-            </tr>
-            <tr>
-              <th scope="row">Record Count</th>
-              {this.state?.legendItems.length &&
+      <div className="barChart">
+        <div className="chartContainer">
+          <canvas ref={this.canvasRef}>
+            <p>
+              Text alternative for this canvas graphic is in the data table below.
+            </p>
+          <table
+            border="0"
+            cellPadding="5"
+            summary="This is the text alternative for the canvas graphic."
+          >
+            <caption>Records Indexed for Jetpack Search</caption>
+            <tbody>
+              <tr>
+                <th scope="col">Post Type</th>
+                {this.state?.legendItems.length &&
+                  this.state.legendItems.map((item) => {
+                    return <th scope="col">{item.text}</th>;
+                  })}
+              </tr>
+              <tr>
+                <th scope="row">Record Count</th>
+                {this.state?.legendItems.length &&
+                  this.state.legendItems.map((item) => {
+                    return (
+                      <td>{this.props.data[item.datasetIndex].data.data}</td>
+                    );
+                  })}
+              </tr>
+            </tbody>
+          </table>
+          </canvas>
+          </div>
+          <div className="chartLegendContainer">
+            <ul className="chartLegend">
+              {this.state?.legendItems.length > 0 &&
                 this.state.legendItems.map((item) => {
                   return (
-                    <td>{this.props.data[item.datasetIndex].data.data}</td>
+                    <li key={item.text}>
+                      <div
+                        className="chartLegendBox"
+                        style={{
+                          backgroundColor: item.fillStyle,
+                        }}
+                      />
+                      <span className="chartLegendLabel" children={item.text} />
+                      <span className="chartLegendCount">
+                        ({this.props.data[item.datasetIndex].data.data})
+                      </span>
+                    </li>
                   );
                 })}
-            </tr>
-          </tbody>
-        </table>
-        </canvas>
-        <ul className="chartLegend">
-        
-          {this.state?.legendItems.length > 0 &&
-            this.state.legendItems.map((item) => {
-              return (
-                <li key={item.text}>
-                  <div
-                    className="chartLegendBox"
-                    style={{
-                      backgroundColor: item.fillStyle,
-                    }}
-                  />
-                  <span className="chartLegendLabel" children={item.text} />
-                  <span className="chartLegendCount">
-                    ({this.props.data[item.datasetIndex].data.data})
-                  </span>
-                </li>
-              );
-            })}
-        </ul>
+            </ul>
+          </div>
         </div>
     );
   }

--- a/src/components/NoticeBox.js
+++ b/src/components/NoticeBox.js
@@ -1,13 +1,15 @@
 import React from "react";
 
 export function NoticeBox(props) {
-  if (props.errors.length == 0) {
+  if ( ! props.errors ) {
     return null;
   }
 
   return (
-    <div className={props.className}>
-      {props.errors && <p>{props.errors[0]}</p>}
+    <div className={ props.className }> 
+        <p>
+          {props.errors[0]}
+        </p>
     </div>
   );
 }

--- a/src/components/RecordCount.js
+++ b/src/components/RecordCount.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export function RecordCount(props) {
   return (
-    <div>
+    <div className="recordCount">
       {props.recordCount && props.planRecordLimit && (
         <p>
           {props.recordCount} records indexed out of the {props.planRecordLimit}{" "}


### PR DESCRIPTION
During a review today we talked about the notice box and the legend overlapping. This PR fixes them by restructuring the HTML slightly to move the legend out of the main chart div (which has a max-height of 40px).

<img width="1194" alt="Screen Shot 2022-01-12 at 15 01 40" src="https://user-images.githubusercontent.com/17325/149050671-d9c31b5a-d694-4530-bb86-910425e6ce27.png">

New HTML structure:

<img width="341" alt="Screen Shot 2022-01-12 at 15 02 26" src="https://user-images.githubusercontent.com/17325/149050758-200b4f05-c4e7-4171-874e-8128289fb474.png">


